### PR TITLE
Fixing `Undefined offset: 5` Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ $callback = function($payload)
 $client->subscribe("foo", $callback);
 
 # Request
-$c->request('sayhello', 'Marty McFly', function ($response) {
+$client->request('sayhello', 'Marty McFly', function ($response) {
     echo $response->getBody();
 });
 
 # Responding to requests
-$sid = $c->subscribe("sayhello", function ($res) {
+$sid = $client->subscribe("sayhello", function ($res) {
     $res->reply("Hello, " . $res->getBody() . " !!!");
 });
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -341,7 +341,7 @@ class Connection
         $sid = $parts[2];
 
         if (count($parts) == 5) {
-            $length = $parts[5];
+            $length = $parts[4];
             $subject = $parts[3];
         } elseif (count($parts) == 4) {
             $length = $parts[3];


### PR DESCRIPTION
Fixes a notice `Undefined offset: 5` which pops up on my local system using the current NATS Docker Image `0.7.2` (https://hub.docker.com/_/nats/) and `phpnats` `0.6.0`.

I do not have that much time at the moment and the passage in `Connection` class is currently not covered by tests.