### PR TITLE
Missing Best Practice

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -307,7 +307,7 @@ class Connection
      */
     public function queueSubscribe($subject, $queue, \Closure $callback)
     {
-        $sid = uniqid();
+        $sid = openssl_random_pseudo_bytes(16);
         $msg = 'SUB '.$subject.' '.$queue.' '. $sid;
         $this->send($msg);
         $this->subscriptions[$sid] = $callback;


### PR DESCRIPTION
uniqid does not create random nor unpredictable string. This function must not be used for security purposes.  If you need to generate cryptographically secure tokens use openssl_random_pseudo_bytes().