### PR TITLE
TASK: Fix php doc in Message::getConn method

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -30,7 +30,7 @@ class Message
     /**
      * Message related connection.
      *
-     * @var string
+     * @var Connection
      */
     private $conn;
 
@@ -146,7 +146,7 @@ class Message
     /**
      * Get Conn.
      *
-     * @return string
+     * @return Connection
      */
     public function getConn()
     {


### PR DESCRIPTION
The conn property is not a string but an instance of Connection.