### PR TITLE
Fix corrupt reads.

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -177,6 +177,9 @@ class Connection
                 $line .= fread($this->streamSocket, $chunkSize);
                 $receivedBytes += $chunkSize;
             }
+            if (strlen($line) > 2) {
+                $line = substr($line, 0, -2);
+            }
         } else {
             $line = fgets($this->streamSocket);
         }


### PR DESCRIPTION
Now continuously reads from stream in chunks until whole message is received.

Apparently `fread` stops when first packet is received, regardless if that's the whole message.