### PR TITLE
Fixed incorrect check of bytes left when reading

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -187,7 +187,7 @@ class Connection
             $receivedBytes = 0;
             while ($receivedBytes < $len) {
                 $bytesLeft = $len - $receivedBytes;
-                if ( $bytesLeft < 1500 ) {
+                if ( $bytesLeft < $this->chunkSize ) {
                     $chunkSize = $bytesLeft;
                 }
 


### PR DESCRIPTION
I missed this :o Sorry, only saw it when I plugged everything into my environment. Had been 1500 initially before I allowed for a user defined chunk size.