### PR TITLE
BUGFIX: Never truncate the message on receive

### DIFF
--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -174,9 +174,6 @@ class Connection
                 $line .= fread($this->streamSocket, $chunkSize);
                 $receivedBytes += $chunkSize;
             }
-            if (strlen($line) > 2) {
-                $line = substr($line, 0, -2);
-            }
         } else {
             $line = fgets($this->streamSocket);
         }


### PR DESCRIPTION
This fix a regression introduced by 851d8819940ddbc0ed66a8e69e274495208c9001