### PR TITLE
Suppress warnings on stream_socket_client

### DIFF
--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -195,15 +195,18 @@ class Connection
         $errno = null;
         $errstr = null;
 
+        set_error_handler(function(){return true;});
         $fp = stream_socket_client($address, $errno, $errstr, $timeout, STREAM_CLIENT_CONNECT);
-        $timeout = number_format($timeout, 3);
-        $seconds = floor($timeout);
-        $microseconds = ($timeout - $seconds) * 1000;
-        stream_set_timeout($fp, $seconds, $microseconds);
+        restore_error_handler();
 
         if (!$fp) {
             throw new \Exception($errstr, $errno);
         }
+
+        $timeout = number_format($timeout, 3);
+        $seconds = floor($timeout);
+        $microseconds = ($timeout - $seconds) * 1000;
+        stream_set_timeout($fp, $seconds, $microseconds);
 
         return $fp;
     }

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -205,4 +205,23 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(true);
     }
+
+
+    /**
+     * Test Connecting when nats server is not available
+     *
+     * @return void
+     */
+    public function testRefusedConnection()
+    {
+        $this->setExpectedException(\Exception::class);
+
+        $options = new ConnectionOptions();
+        $options->setHost('localhost');
+        $options->setPort(4223);
+
+        $c = new Nats\Connection($options);
+        $c->connect();
+        $this->assertFalse($this->c->isConnected());
+    }
 }


### PR DESCRIPTION
When calling stream_socket_client and gnatsd is not running, stream_socket_client throws warnings , not exceptions. So I have added void error handler that suppresses just this call end then pops out of an error handler stack. 

And if stream handle does not exist, now exception is thrown before trying to call stream_set_timeout. 

Tests are added by using hopefully non used port in travis. 
