### PR TITLE
TASK: More solid method to send payload to the socket

### DIFF
--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -148,7 +148,21 @@ class Connection
     private function send($payload)
     {
         $msg = $payload."\r\n";
-        fwrite($this->streamSocket, $msg, strlen($msg));
+        $len = strlen($msg);
+        while (true) {
+            if (false === ($written = @fwrite($this->streamSocket, $msg))) {
+                throw new \Exception('Error sending data');
+            }
+            if ($written === 0) {
+                throw new \Exception('Broken pipe or closed connection');
+            }
+            $len = $len - $written;
+            if ($len > 0) {
+                $msg = substr($msg, 0 - $len);
+            } else {
+                break;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I can happens that fwrite does exit but without sending the full payload, or it can also happen that the pipe is closed or broken. With the change the logic a bit more complex but retry write operation. We need to silently ignore (@fwrite) notice/warnings from fwrite to be able to catch the broken pipe error (without the silent operator fwrite, will return a notice, and depending on the user php configuration, error handler, level, ... this can be converted to an exception or something that will skip the retry logic and our exception)