### PR TITLE
TASK: Close should check if the current socket is null

### DIFF
--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -492,6 +492,9 @@ class Connection
      */
     public function close()
     {
+        if ($this->streamSocket === null) {
+            return;
+        }
         fclose($this->streamSocket);
         $this->streamSocket = null;
     }


### PR DESCRIPTION
If we call close (by ex. during a reconnect) but the streamSocket is null, we generate useless error for the user.