### PR TITLE
Feature/phpcs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
 before_script:
   - make deps
 script:
+  - mkdir -p lint-php
   - mkdir -p build/logs
   - make test
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_install:
 before_script:
   - make deps
 script:
-  - mkdir -p lint-php
   - mkdir -p build/logs
+  - make lint-php
   - make test
 after_script:
   - php vendor/bin/coveralls

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint-squiz:
 test: test-tdd test-bdd
 
 .PHONY: test-tdd
-test-bdd:
+test-tdd:
 	./vendor/bin/phpunit test
 
 .PHONY: test-bdd

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
-lint:
+lint: lint-php lint-psr2 lint-squiz
+
+lint-php:
 	find src -name *.php -exec php -l {} \;
 	find test -name *.php -exec php -l {} \;
 	find spec -name *.php -exec php -l {} \;
 	find examples -name *.php -exec php -l {} \;
 
-cs: lint
-	./vendor/bin/phpcbf --standard=PSR2 src test examples
-	./vendor/bin/phpcs --standard=PSR2 --warning-severity=0 src test examples
-	./vendor/bin/phpcs --standard=Squiz --sniffs=Squiz.Commenting.FunctionComment,Squiz.Commenting.FunctionCommentThrowTag,Squiz.Commenting.ClassComment,Squiz.Commenting.VariableComment src test examples
+lint-psr2:
+	#./vendor/bin/phpcbf --standard=PSR2 src test examples
+	./vendor/bin/phpcs --standard=PSR2 --colors -w -s --warning-severity=0 src test examples
+
+lint-squiz:
+	# ./vendor/bin/phpcbf --standard=Squiz,./ruleset.xml src test examples
+	./vendor/bin/phpcs --standard=Squiz,./ruleset.xml --colors -w -s --warning-severity=0 src test examples
+
 
 test: tdd bdd
 

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,31 @@
 lint: lint-php lint-psr2 lint-squiz
 
+.PHONY: lint-php
 lint-php:
 	find src -name *.php -exec php -l {} \;
 	find test -name *.php -exec php -l {} \;
 	find spec -name *.php -exec php -l {} \;
 	find examples -name *.php -exec php -l {} \;
 
+.PHONY: lint-psr2
 lint-psr2:
 	#./vendor/bin/phpcbf --standard=PSR2 src test examples
 	./vendor/bin/phpcs --standard=PSR2 --colors -w -s --warning-severity=0 src test examples
 
+.PHONY: lint-squiz
 lint-squiz:
 	# ./vendor/bin/phpcbf --standard=Squiz,./ruleset.xml src test examples
 	./vendor/bin/phpcs --standard=Squiz,./ruleset.xml --colors -w -s --warning-severity=0 src test examples
 
 
-test: tdd bdd
+test: test-tdd test-bdd
 
-tdd:
+.PHONY: test-tdd
+test-bdd:
 	./vendor/bin/phpunit test
 
-bdd:
+.PHONY: test-bdd
+test-bdd:
 	./vendor/bin/phpspec run --format=pretty -v
 
 cover:
@@ -49,5 +54,3 @@ phpdoc:
 
 serve-phpdoc:
 	cd docs/api && php -S localhost:8000 && cd ../..
-
-.PHONY: lint test cs cover deps dist-clean

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Standard">
+    <description>php-nats Coding Standards for Inline Documentation and Comments</description>
+
+    <rule ref="Squiz.Commenting">
+        <!-- It is too early for PHP7 features to be required -->
+        <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
**Refactored makefile lint tasks:**

* One task to lint with PHP
* One task to lint with PHP Code Sniffer using PSR2 standard
* One task to lint with PHP Code Sniffer and Squiz rules about docblocks
and other general checks.
* One task to execute all ( and one ring to rule them all )

So you can execute:

```

$ make lint-php
$ make lint-psr2
$ make lint-squiz
$ make lint
```

**Current CI configuration:**

Added `lint-php`task to travis. PSR2 and Squiz will be added on future PRs.
