### PR TITLE
Fixed unnecessary extra encoding

### DIFF
--- a/src/Nats/EncodedConnection.php
+++ b/src/Nats/EncodedConnection.php
@@ -32,21 +32,6 @@ class EncodedConnection extends Connection
     }
 
     /**
-     * Request does a request and executes a callback with the response.
-     *
-     * @param string   $subject  Message topic.
-     * @param string   $payload  Message data.
-     * @param \Closure $callback Closure to be executed as callback.
-     *
-     * @return void
-     */
-    public function request($subject, $payload, \Closure $callback)
-    {
-        $payload = $this->encoder->encode($payload);
-        parent::request($subject, $payload, $callback);
-    }
-
-    /**
      * Publish publishes the data argument to the given subject.
      *
      * @param string $subject Message topic.

--- a/test/Encoders/JSONEncoderTest.php
+++ b/test/Encoders/JSONEncoderTest.php
@@ -57,5 +57,7 @@ class JSONEncoderTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals('Hello, McFly !!!', $res->getBody());
             }
         );
+        
+        $this->c->wait(1);
     }
 }

--- a/test/Encoders/PHPEncoderTest.php
+++ b/test/Encoders/PHPEncoderTest.php
@@ -57,5 +57,7 @@ class PHPEncoderTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals('Hello, McFly !!!', $res->getBody());
             }
         );
+        
+        $this->c->wait(1);
     }
 }

--- a/test/Encoders/YAMLEncoderTest.php
+++ b/test/Encoders/YAMLEncoderTest.php
@@ -61,5 +61,7 @@ class YAMLEncoderTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals('Hello, McFly !!!', $res->getBody());
             }
         );
+        
+        $this->c->wait(1);
     }
 }


### PR DESCRIPTION
`request` catch the message for `subscribe` and does not `wait` reply on request. 
Added extra waiting.
Resolves #110 