### PR TITLE
Add support for all callable type not just Closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,12 @@
     ],
     "autoload": {
         "psr-0": {
-            "Nats": "src",
-            "Nats\\Test": "src"
+            "Nats": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Nats\\tests\\Unit\\": "test/"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
 
     <testsuites>
         <testsuite name="PHPNats Test Suite">
-            <directory suffix=".php">./tests/Unit/</directory>
+            <directory suffix=".php">./test/</directory>
         </testsuite>
     </testsuites>
     <logging>

--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -481,11 +481,11 @@ class Connection
      *
      * @param string   $subject  Message topic.
      * @param string   $payload  Message data.
-     * @param \Closure $callback Closure to be executed as callback.
+     * @param callable $callback Closure to be executed as callback.
      *
      * @return void
      */
-    public function request($subject, $payload, \Closure $callback)
+    public function request($subject, $payload, callable $callback)
     {
         $inbox = uniqid('_INBOX.');
         $sid   = $this->subscribe(
@@ -501,11 +501,11 @@ class Connection
      * Subscribes to an specific event given a subject.
      *
      * @param string   $subject  Message topic.
-     * @param \Closure $callback Closure to be executed as callback.
+     * @param callable $callback Closure to be executed as callback.
      *
      * @return string
      */
-    public function subscribe($subject, \Closure $callback)
+    public function subscribe($subject, callable $callback)
     {
         $sid = $this->randomGenerator->generateString(16);
         $msg = 'SUB '.$subject.' '.$sid;
@@ -519,11 +519,11 @@ class Connection
      *
      * @param string   $subject  Message topic.
      * @param string   $queue    Queue name.
-     * @param \Closure $callback Closure to be executed as callback.
+     * @param callable $callback Closure to be executed as callback.
      *
      * @return string
      */
-    public function queueSubscribe($subject, $queue, \Closure $callback)
+    public function queueSubscribe($subject, $queue, callable $callback)
     {
         $sid = $this->randomGenerator->generateString(16);
         $msg = 'SUB '.$subject.' '.$queue.' '.$sid;

--- a/src/Nats/EncodedConnection.php
+++ b/src/Nats/EncodedConnection.php
@@ -36,11 +36,11 @@ class EncodedConnection extends Connection
      *
      * @param string   $subject  Message topic.
      * @param string   $payload  Message data.
-     * @param \Closure $callback Closure to be executed as callback.
+     * @param callable $callback Closure to be executed as callback.
      *
      * @return void
      */
-    public function request($subject, $payload, \Closure $callback)
+    public function request($subject, $payload, callable $callback)
     {
         $payload = $this->encoder->encode($payload);
         parent::request($subject, $payload, $callback);
@@ -65,11 +65,11 @@ class EncodedConnection extends Connection
      * Subscribes to an specific event given a subject.
      *
      * @param string   $subject  Message topic.
-     * @param \Closure $callback Closure to be executed as callback.
+     * @param callable $callback Closure to be executed as callback.
      *
      * @return string
      */
-    public function subscribe($subject, \Closure $callback)
+    public function subscribe($subject, callable $callback)
     {
         $c = function ($message) use ($callback) {
             $message->setBody($this->encoder->decode($message->getBody()));
@@ -83,11 +83,11 @@ class EncodedConnection extends Connection
      *
      * @param string   $subject  Message topic.
      * @param string   $queue    Queue name.
-     * @param \Closure $callback Closure to be executed as callback.
+     * @param callable $callback Closure to be executed as callback.
      *
      * @return void
      */
-    public function queueSubscribe($subject, $queue, \Closure $callback)
+    public function queueSubscribe($subject, $queue, callable $callback)
     {
         $c = function ($message) use ($callback) {
             $message->setBody($this->encoder->decode($message->getBody()));

--- a/test/CallableClass.php
+++ b/test/CallableClass.php
@@ -1,0 +1,40 @@
+<?php
+namespace Nats\tests\Unit;
+
+class CallableClass
+{
+    private $tmpStorage = [];
+    private $tmpCallbacks = [];
+
+    public function requestSubTest($res)
+    {
+        $res->reply('Hello, '.$res->getBody());
+    }
+    public function __invoke($res)
+    {
+        $msg = $res->getBody();
+        $p = explode(' ', $msg);
+        $count = array_pop($p);
+        if (isset($this->tmpCallbacks[$count])) {
+            $cb = $this->tmpCallbacks[$count];
+            $cb($msg, $count);
+            unset($this->tmpCallbacks[$count]);
+        } else {
+            $this->tmpStorage[$count] = $msg;
+        }
+    }
+
+    public function getMsg()
+    {
+        return $this->msg;
+    }
+
+    public function test($i, callable $param)
+    {
+        if (isset($this->tmpStorage[$i])) {
+            $param($this->tmpStorage[$i], $i);
+        } else {
+            $this->tmpCallbacks[$i] = $param;
+        }
+    }
+}

--- a/test/ConnectionTest.php
+++ b/test/ConnectionTest.php
@@ -225,4 +225,33 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $c->connect();
         $this->assertFalse($this->c->isConnected());
     }
+
+    /**
+     * Test having a class a callable
+     *
+     * @return void
+     */
+    public function testCallableRequest()
+    {
+        $testCallable = new CallableClass();
+
+        $i = 0;
+        do {
+            $this->c->subscribe(
+                'sayhello' . $i,
+                [$testCallable, 'requestSubTest']
+            );
+
+            /* Test __invoke */
+            $this->c->request(
+                'sayhello' . $i,
+                'McFly ' . $i,
+                $testCallable
+            );
+            $testCallable->test($i, function ($msg, $i) {
+                $this->assertEquals('Hello, McFly ' . $i, $msg);
+            });
+            $i++;
+        } while ($i < 100);
+    }
 }


### PR DESCRIPTION
Needed support to use classes as callback argument.

And `Closure` is also a `callable` so no this did't break any tests.

I know the test isn't the best if someone can give me some pointer I would gladly improve it.