### PR TITLE
fixes ssl_required field of serverinfo for v1.1.0

### DIFF
--- a/src/Nats/ServerInfo.php
+++ b/src/Nats/ServerInfo.php
@@ -103,10 +103,13 @@ class ServerInfo
         $this->setVersion($data['version']);
         $this->setGoVersion($data['go']);
         $this->setAuthRequired($data['auth_required']);
-        $this->setSSLRequired($data['ssl_required']);
         $this->setTLSRequired($data['tls_required']);
         $this->setTLSVerify($data['tls_verify']);
         $this->setMaxPayload($data['max_payload']);
+
+        if (version_compare($data['version'], '1.1.0') === -1) {
+            $this->setSSLRequired($data['ssl_required']);
+        }
     }
 
     /**


### PR DESCRIPTION
ssl_required field removed v1.1.0
release notes: [https://github.com/nats-io/gnatsd/releases/tag/v1.1.0](https://github.com/nats-io/gnatsd/releases/tag/v1.1.0)