### PR TITLE
Check if 'ssl_required' is set in connection response

### DIFF
--- a/src/Nats/ServerInfo.php
+++ b/src/Nats/ServerInfo.php
@@ -103,7 +103,7 @@ class ServerInfo
         $this->setVersion($data['version']);
         $this->setGoVersion($data['go']);
         $this->setAuthRequired($data['auth_required']);
-        $this->setSSLRequired($data['ssl_required']);
+        $this->setSSLRequired(isset($data['ssl_required']) ? $data['ssl_required'] : false);
         $this->setTLSRequired($data['tls_required']);
         $this->setTLSVerify($data['tls_verify']);
         $this->setMaxPayload($data['max_payload']);


### PR DESCRIPTION
On newer versions of nats the 'ssl_required' key isn't (always?) set in the connection info.
Just made an isset check for it.