### PR TITLE
Fixes #129 Adding optional params to number_format

### DIFF
--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -177,7 +177,7 @@ class Connection
         if ($this->isConnected() === true) {
             if (is_numeric($seconds) === true) {
                 try {
-                    $timeout      = number_format($seconds, 3);
+                    $timeout      = number_format($seconds, 3, '.', '');
                     $seconds      = floor($timeout);
                     $microseconds = (($timeout - $seconds) * 1000);
                     return stream_set_timeout($this->streamSocket, $seconds, $microseconds);
@@ -250,7 +250,7 @@ class Connection
             throw Exception::forStreamSocketClientError($errstr, $errno);
         }
 
-        $timeout      = number_format($timeout, 3);
+        $timeout      = number_format($timeout, 3, '.', '');
         $seconds      = floor($timeout);
         $microseconds = (($timeout - $seconds) * 1000);
         stream_set_timeout($fp, $seconds, $microseconds);


### PR DESCRIPTION
Fixes issue where numbers over 999 are formatted incorrectly