### PR TITLE
Calculate stream timeout correctly

### DIFF
--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -168,22 +168,20 @@ class Connection
     /**
      * Set Stream Timeout.
      *
-     * @param float $seconds Before timeout on stream.
+     * @param float $timeout Before timeout on stream.
      *
      * @return boolean
      */
-    public function setStreamTimeout($seconds)
+    public function setStreamTimeout($timeout)
     {
-        if ($this->isConnected() === true) {
-            if (is_numeric($seconds) === true) {
-                $timeout      = number_format($seconds, 3);
-                $seconds      = floor($timeout);
-                $microseconds = (($timeout - $seconds) * 1000);
-                return stream_set_timeout($this->streamSocket, $seconds, $microseconds);
-            }
-        }
+        if ($this->isConnected() === false) return false;
+        if (is_numeric($timeout) === false) return false;
 
-        return false;
+        $seconds = intval($timeout);
+        if ($seconds < 0) return false;
+
+        $microseconds = intval(round($timeout - $seconds, 3) * 1000);
+        return stream_set_timeout($this->streamSocket, $seconds, $microseconds);
     }
 
     /**

--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -227,12 +227,11 @@ class Connection
      * Returns an stream socket to the desired server.
      *
      * @param string $address Server url string.
-     * @param float  $timeout Number of seconds until the connect() system call should timeout.
      *
      * @throws \Exception Exception raised if connection fails.
      * @return resource
      */
-    private function getStream($address, $timeout, $context)
+    private function getStream($address, $context)
     {
         $errno  = null;
         $errstr = null;
@@ -249,11 +248,6 @@ class Connection
         if ($fp === false) {
             throw Exception::forStreamSocketClientError($errstr, $errno);
         }
-
-        $timeout      = number_format($timeout, 3);
-        $seconds      = floor($timeout);
-        $microseconds = (($timeout - $seconds) * 1000);
-        stream_set_timeout($fp, $seconds, $microseconds);
 
         return $fp;
     }
@@ -444,8 +438,7 @@ class Connection
         }
 
         $this->timeout      = $timeout;
-        $this->streamSocket = $this->getStream(
-            $this->options->getAddress(), $timeout, $this->options->getStreamContext());
+        $this->streamSocket = $this->getStream($this->options->getAddress(), $this->options->getStreamContext());
         $this->setStreamTimeout($timeout);
 
         $infoResponse = $this->receive();

--- a/src/Nats/Connection.php
+++ b/src/Nats/Connection.php
@@ -176,14 +176,10 @@ class Connection
     {
         if ($this->isConnected() === true) {
             if (is_numeric($seconds) === true) {
-                try {
-                    $timeout      = number_format($seconds, 3);
-                    $seconds      = floor($timeout);
-                    $microseconds = (($timeout - $seconds) * 1000);
-                    return stream_set_timeout($this->streamSocket, $seconds, $microseconds);
-                } catch (\Exception $e) {
-                    return false;
-                }
+                $timeout      = number_format($seconds, 3);
+                $seconds      = floor($timeout);
+                $microseconds = (($timeout - $seconds) * 1000);
+                return stream_set_timeout($this->streamSocket, $seconds, $microseconds);
             }
         }
 


### PR DESCRIPTION
This PR improves the way the stream timeout is handled. More specifically:

- The timeout is only set once during the creation of the stream. This is done through the `setStreamTimeout` method once the stream has been created.
- The unnecessary try-catch block in `setStreamTimeout`  is removed.
- The `number_format` call for calculating the stream timeout is error-prone. It is replaced with int-casting and a call to `round`.
- The `stream_set_timeout` emits a warning when float values are provided instead of ints. This solution ensures only ints are provided. The current solution and PR #132 don't fully account for this situation.
- Strange timeout values are denied. This for example includes negative values and values greater than `PHP_INT_MAX`.